### PR TITLE
hardware: interfaces: bt: Add missing hardware directory in include.

### DIFF
--- a/interfaces/bluetooth/1.0/qti/service.cpp
+++ b/interfaces/bluetooth/1.0/qti/service.cpp
@@ -16,7 +16,7 @@
 
 #define LOG_TAG "android.hardware.bluetooth@1.0-service-qti"
 
-#include <android/bluetooth/1.0/IBluetoothHci.h>
+#include <android/hardware/bluetooth/1.0/IBluetoothHci.h>
 
 #include <hidl/LegacySupport.h>
 


### PR DESCRIPTION
This word got lost when the commit was transferred from:
https://github.com/sonyxperiadev/device-sony-common/pull/550/commits/59fe545852436a53547373ef05811edd2ec9ad30#diff-79ad0d43d3d61318a9d109ba2738447fR19
Add it back to make the HAL compile again.