### PR TITLE
[R/Q] android.bp: Remove libhidltransport from shared libs

### DIFF
--- a/interfaces/bluetooth/1.0/qti/Android.bp
+++ b/interfaces/bluetooth/1.0/qti/Android.bp
@@ -14,7 +14,6 @@ cc_binary {
         "libutils",
         "libhardware",
         "libhidlbase",
-        "libhidltransport",
         "android.hardware.bluetooth@1.0",
     ],
 }


### PR DESCRIPTION
In Android R libhidltransport is no longer available to use.
Thus remove this library.